### PR TITLE
use event delegation to catch dynamically-loaded share buttons

### DIFF
--- a/app.json
+++ b/app.json
@@ -103,7 +103,6 @@
       "required": true
     }
   },
-  },
   "formation": {
     "web": {
       "quantity": 1,
@@ -121,10 +120,10 @@
   ],
   "buildpacks": [
     {
-      "url": "heroku/nodejs"
+      "url": "heroku/ruby"
     },
     {
-      "url": "heroku/ruby"
+      "url": "heroku/nodejs"
     }
   ]
 }

--- a/site/_js/client.js
+++ b/site/_js/client.js
@@ -47,15 +47,28 @@ var FreeProgress = {
 
   onDomContentLoaded: function() {
     document.addEventListener('click', function(e) {
-      e.preventDefault();
-      console.log(e);
-      if (e.target.tagName == 'BUTTON' || e.target.tagName == 'A') {
-        if (e.target.classList.contains('facebook')) {
-          e.preventDefault();
-          this.share();
-        } else if (e.target.classList.contains('twitter')) {
-          e.preventDefault();
-          this.tweet();
+      var targets = document.querySelectorAll('a.facebook, button.facebook, a.twitter, button.twitter');
+
+      var el = e.target;
+      var p;
+
+      for (var i = 0; i < targets.length; i++) {
+        p = possibleTargets[i];
+
+        while (el && el !== document) {
+          if (el === p) {
+            e.preventDefault();
+
+            if (p.classList.contains('facebook')) {
+              this.share();
+            } else if (p.classList.contains('twitter')) {
+              this.tweet();
+            }
+
+            return fn.call(p, e);
+          }
+
+          el = el.parentNode;
         }
       }
     }.bind(this), false);

--- a/site/_js/client.js
+++ b/site/_js/client.js
@@ -46,30 +46,32 @@ var FreeProgress = {
   },
 
   onDomContentLoaded: function() {
+    // Polyfill matches selector
+    function matches(el, selector) {
+      var matchesSelector = el.matches || el.webkitMatchesSelector ||
+        el.mozMatchesSelector || el.msMatchesSelector || el.oMatchesSelector ||
+        function(selector) {
+          var matches = document.querySelectorAll(selector);
+          while (matches[i] && matches[i] !== element) { i++; }
+          return matches[i] ? true : false;
+        };
+
+      return matchesSelector.call(el, selector); 
+    }
+
     document.addEventListener('click', function(e) {
-      var targets = document.querySelectorAll('a.facebook, button.facebook, a.twitter, button.twitter');
-
       var el = e.target;
-      var p;
 
-      for (var i = 0; i < targets.length; i++) {
-        p = targets[i];
-
-        while (el && el !== document) {
-          if (el === p) {
-            e.preventDefault();
-
-            if (p.classList.contains('facebook')) {
-              this.share();
-            } else if (p.classList.contains('twitter')) {
-              this.tweet();
-            }
-
-            return fn.call(p, e);
-          }
-
-          el = el.parentNode;
+      while (el && el !== document) {
+        if (matches(el, 'a.facebook, button.facebook')) {
+          e.preventDefault();
+          this.share();
+        } else if (matches(el, 'a.twitter, button.twitter')) {
+          e.preventDefault();
+          this.tweet();
         }
+
+        el = el.parentNode;
       }
     }.bind(this), false);
   },

--- a/site/_js/client.js
+++ b/site/_js/client.js
@@ -46,7 +46,7 @@ var FreeProgress = {
   },
 
   onDomContentLoaded: function() {
-    document.addEventListener('click', function(e) {
+    document.body.addEventListener('click', function(e) {
       e.preventDefault();
       debugger;
       if (e.currentTarget.tagName == 'BUTTON' || e.currentTarget.tagName == 'A') {

--- a/site/_js/client.js
+++ b/site/_js/client.js
@@ -49,12 +49,11 @@ var FreeProgress = {
     document.addEventListener('click', function(e) {
       e.preventDefault();
       console.log(e);
-      debugger;
-      if (e.currentTarget.tagName == 'BUTTON' || e.currentTarget.tagName == 'A') {
-        if (e.currentTarget.classList.contains('facebook')) {
+      if (e.target.tagName == 'BUTTON' || e.target.tagName == 'A') {
+        if (e.target.classList.contains('facebook')) {
           e.preventDefault();
           this.share();
-        } else if (e.currentTarget.classList.contains('twitter')) {
+        } else if (e.target.classList.contains('twitter')) {
           e.preventDefault();
           this.tweet();
         }

--- a/site/_js/client.js
+++ b/site/_js/client.js
@@ -45,20 +45,18 @@ var FreeProgress = {
         false);
   },
 
-  onDomContentLoaded:function() {
-    var fb = document.querySelectorAll('button.facebook, a.facebook');
-    for (var i = 0; i < fb.length; i++)
-      fb[i].addEventListener('click', function(e) {
-        e.preventDefault();
-        this.share();
-      }.bind(this), false);
-
-    var tw = document.querySelectorAll('button.twitter, a.twitter');
-    for (var i = 0; i < tw.length; i++)
-      tw[i].addEventListener('click', function(e) {
-        e.preventDefault();
-        this.tweet();
-      }.bind(this), false);
+  onDomContentLoaded: function() {
+    document.addEventListener('click', function(e) {
+      if (e.currentTarget.tagName == 'BUTTON' || e.currentTarget.tagName == 'A') {
+        if (e.currentTarget.classList.contains('facebook')) {
+          e.preventDefault();
+          this.share();
+        } else if (e.currentTarget.classList.contains('twitter')) {
+          e.preventDefault();
+          this.tweet();
+        }
+      }
+    }.bind(this), false);
   },
 
   share: function() {

--- a/site/_js/client.js
+++ b/site/_js/client.js
@@ -47,6 +47,7 @@ var FreeProgress = {
 
   onDomContentLoaded: function() {
     document.addEventListener('click', function(e) {
+      debugger;
       if (e.currentTarget.tagName == 'BUTTON' || e.currentTarget.tagName == 'A') {
         if (e.currentTarget.classList.contains('facebook')) {
           e.preventDefault();

--- a/site/_js/client.js
+++ b/site/_js/client.js
@@ -53,7 +53,7 @@ var FreeProgress = {
       var p;
 
       for (var i = 0; i < targets.length; i++) {
-        p = possibleTargets[i];
+        p = targets[i];
 
         while (el && el !== document) {
           if (el === p) {

--- a/site/_js/client.js
+++ b/site/_js/client.js
@@ -47,6 +47,7 @@ var FreeProgress = {
 
   onDomContentLoaded: function() {
     document.addEventListener('click', function(e) {
+      e.preventDefault();
       debugger;
       if (e.currentTarget.tagName == 'BUTTON' || e.currentTarget.tagName == 'A') {
         if (e.currentTarget.classList.contains('facebook')) {

--- a/site/_js/client.js
+++ b/site/_js/client.js
@@ -46,8 +46,9 @@ var FreeProgress = {
   },
 
   onDomContentLoaded: function() {
-    document.body.addEventListener('click', function(e) {
+    document.addEventListener('click', function(e) {
       e.preventDefault();
+      console.log(e);
       debugger;
       if (e.currentTarget.tagName == 'BUTTON' || e.currentTarget.tagName == 'A') {
         if (e.currentTarget.classList.contains('facebook')) {


### PR DESCRIPTION
Allows things like dynamically-created modals to utilize FreeProgress for share buttons. Need to test this before merging.