### PR TITLE
allow non-unique user agent log entries

### DIFF
--- a/app/model/user_agent_log.js
+++ b/app/model/user_agent_log.js
@@ -9,7 +9,8 @@ var _init = function(baseModel) {
   var UserAgentLog = baseModel._sequelize.define('site',
     {
       user_agent: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
+        unique: false
       },
       create_date: {
         type: Sequelize.DATE,

--- a/app/model/user_agent_log.js
+++ b/app/model/user_agent_log.js
@@ -9,8 +9,7 @@ var _init = function(baseModel) {
   var UserAgentLog = baseModel._sequelize.define('site',
     {
       user_agent: {
-        type: Sequelize.STRING,
-        unique: true
+        type: Sequelize.STRING
       },
       create_date: {
         type: Sequelize.DATE,


### PR DESCRIPTION
Intent of this patch is to avoid the error seen below, which manifests in silent failures when attempting to add or update new variations. Proper fix would include actually handling this error, but I'm unclear on why a user agent would be expected to be unique.

```
Jun 22 12:49:59 freeprogress app/web.1: Executing (default): INSERT INTO "_fp_user_agent_log" ("id","user_agent","create_date") VALUES (DEFAULT,'Mozilla/5.0 (Linux; Android 7.0; SM-G950U Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/129.0.0.29.67;]','2017-06-22 19:49:58.000 +00:00') RETURNING *; 
Jun 22 12:49:59 freeprogress app/web.1: Unhandled rejection SequelizeUniqueConstraintError: Validation error 
Jun 22 12:49:59 freeprogress app/web.1:     at Query.formatError (/app/node_modules/sequelize/lib/dialects/postgres/query.js:326:16) 
Jun 22 12:49:59 freeprogress app/web.1:     at null.<anonymous> (/app/node_modules/sequelize/lib/dialects/postgres/query.js:88:19) 
Jun 22 12:49:59 freeprogress app/web.1:     at emitOne (events.js:77:13) 
Jun 22 12:49:59 freeprogress app/web.1:     at emit (events.js:169:7) 
Jun 22 12:49:59 freeprogress app/web.1:     at Query.handleError (/app/node_modules/pg/lib/query.js:108:8) 
Jun 22 12:49:59 freeprogress app/web.1:     at null.<anonymous> (/app/node_modules/pg/lib/client.js:171:26) 
Jun 22 12:49:59 freeprogress app/web.1:     at emitOne (events.js:77:13) 
Jun 22 12:49:59 freeprogress app/web.1:     at emit (events.js:169:7) 
Jun 22 12:49:59 freeprogress app/web.1:     at TLSSocket.<anonymous> (/app/node_modules/pg/lib/connection.js:109:12) 
Jun 22 12:49:59 freeprogress app/web.1:     at emitOne (events.js:77:13) 
Jun 22 12:49:59 freeprogress app/postgres.21249: [DATABASE] [21-1]  sql_error_code = 23505 ERROR:  duplicate key value violates unique constraint "_fp_user_agent_log_user_agent_key" 
Jun 22 12:49:59 freeprogress app/web.1:     at TLSSocket.emit (events.js:169:7) 
Jun 22 12:49:59 freeprogress app/web.1:     at readableAddChunk (_stream_readable.js:153:18) 
Jun 22 12:49:59 freeprogress app/web.1:     at TLSSocket.Readable.push (_stream_readable.js:111:10) 
Jun 22 12:49:59 freeprogress app/web.1:     at TLSWrap.onread (net.js:540:20) 
```

Additionally, seeing different failures for user agents that are too long.

```
Jun 22 13:25:20 freeprogress app/web.1: Executing (default): INSERT INTO "_fp_user_agent_log" ("id","user_agent","create_date") VALUES (DEFAULT,'Mozilla/5.0 (iPhone; CPU iPhone OS 10_2 like Mac OS X) AppleWebKit/602.3.12 (KHTML, like Gecko) Mobile/14C92 [FBAN/FBIOS;FBAV/97.0.0.43.68;FBBV/61443128;FBDV/iPhone9,3;FBMD/iPhone;FBSN/iOS;FBSV/10.2;FBSS/2;FBCR/O2;FBID/phone;FBLC/en_GB;FBOP/5;FBRV/62584461]','2017-06-22 20:25:20.000 +00:00') RETURNING *; 
Jun 22 13:25:20 freeprogress app/web.1: Unhandled rejection SequelizeDatabaseError: value too long for type character varying(255) 
Jun 22 13:25:20 freeprogress app/web.1:     at Query.formatError (/app/node_modules/sequelize/lib/dialects/postgres/query.js:357:14) 
Jun 22 13:25:20 freeprogress app/web.1:     at null.<anonymous> (/app/node_modules/sequelize/lib/dialects/postgres/query.js:88:19) 
Jun 22 13:25:20 freeprogress app/web.1:     at emitOne (events.js:77:13) 
Jun 22 13:25:20 freeprogress app/web.1:     at emit (events.js:169:7) 
Jun 22 13:25:20 freeprogress app/web.1:     at Query.handleError (/app/node_modules/pg/lib/query.js:108:8) 
Jun 22 13:25:20 freeprogress app/web.1:     at null.<anonymous> (/app/node_modules/pg/lib/client.js:171:26) 
Jun 22 13:25:20 freeprogress app/web.1:     at emitOne (events.js:77:13) 
Jun 22 13:25:20 freeprogress app/web.1:     at emit (events.js:169:7) 
Jun 22 13:25:20 freeprogress app/postgres.21908: [DATABASE] [20-1]  sql_error_code = 22001 ERROR:  value too long for type character varying(255) 
Jun 22 13:25:20 freeprogress heroku/router: at=info method=GET path="/f/f5f283" host=fftf.io request_id=1ea4c1e2-fb50-4c4a-9cfa-e8400fc597b4 fwd="78.151.61.30,162.158.34.101" dyno=web.1 connect=1ms service=14ms status=200 bytes=819 protocol=http 
Jun 22 13:25:20 freeprogress app/web.1:     at TLSSocket.<anonymous> (/app/node_modules/pg/lib/connection.js:109:12) 
Jun 22 13:25:20 freeprogress app/web.1:     at emitOne (events.js:77:13) 
Jun 22 13:25:20 freeprogress app/web.1:     at TLSSocket.emit (events.js:169:7) 
Jun 22 13:25:20 freeprogress app/web.1:     at readableAddChunk (_stream_readable.js:153:18) 
Jun 22 13:25:20 freeprogress app/web.1:     at TLSSocket.Readable.push (_stream_readable.js:111:10) 
Jun 22 13:25:20 freeprogress app/web.1:     at TLSWrap.onread (net.js:540:20) 
```

Failures look like this on the frontend, `POST` to `/tests/fb_variation` returns 200 after 30+ seconds, with this apparently invalid response data, and the edits or new variation never appears in the admin UI.

```
{
  "variation_fb": {
    "shares": 0,
    "clicks": 0,
    "conversions": 0,
    "active": true,
    "create_date": "2017-06-22T19:21:32.000Z",
    "id": 1697,
    "shortcode": "90fc59",
    "page_id": null,
    "site_name": null,
    "title": null,
    "description": null,
    "url": null,
    "image_url": null,
    "mod_date": null
  }
}
```